### PR TITLE
Add short norloge support in palmipede

### DIFF
--- a/core/qqbouchot.h
+++ b/core/qqbouchot.h
@@ -84,6 +84,8 @@ public:
 		bool isStrictHttpsCertif() const { return m_strictHttpsCertif; }
 		void setStrictHttpsCertif(bool strictHttpsCertif) { m_strictHttpsCertif = strictHttpsCertif; }
 
+		bool isShortNorlogeEnabled() const  { return m_short_norloge; }
+
 	private:
 		QStringList m_aliases;
 		QString m_backendUrl;
@@ -97,6 +99,7 @@ public:
 		QString m_ua;
 		QString m_group;
 		bool m_strictHttpsCertif;
+		bool m_short_norloge = true; // si vrai, les posts seuls seuls dans la minutes seront affichés sans secondes dans le palmi
 
 		static const char Separator = ',';
 	};

--- a/core/qqnorloge.cpp
+++ b/core/qqnorloge.cpp
@@ -6,7 +6,8 @@
 
 
 QQNorloge::QQNorloge() :
-	m_norlogeIndex(0)
+	m_norlogeIndex(0),
+	m_uniqueMinute(false)
 {
 }
 
@@ -19,7 +20,8 @@ QQNorloge::QQNorloge(QString bouchot, QString dateh) :
 	m_dateHourPart(dateh.mid(8, 2)),
 	m_dateMinutePart(dateh.mid(10, 2)),
 	m_dateSecondPart(dateh.mid(12, 2)),
-	m_norlogeIndex(0)
+	m_norlogeIndex(0),
+	m_uniqueMinute(false)
 {
 	QStringList indexSpit = dateh.split("^", QString::SkipEmptyParts);
 	if(indexSpit.size() > 1)
@@ -34,7 +36,8 @@ QQNorloge::QQNorloge(const QQNorloge& norloge) :
 	m_dateHourPart(norloge.m_dateHourPart),
 	m_dateMinutePart(norloge.m_dateMinutePart),
 	m_dateSecondPart(norloge.m_dateSecondPart),
-	m_norlogeIndex(norloge.m_norlogeIndex)
+	m_norlogeIndex(norloge.m_norlogeIndex),
+	m_uniqueMinute(norloge.m_uniqueMinute)
 {
 }
 
@@ -92,12 +95,18 @@ QString QQNorloge::toStringPalmi()
 				.append(QString::fromUtf8("#"));
 		startPrint = true;
 	}
-	//On a TOUJOURS l'heure
+	//On a TOUJOURS l'heure SAUF parfois les secondes
 	rep.append(m_dateHourPart)
 			.append(QString::fromUtf8(":"))
-			.append(m_dateMinutePart)
-			.append(QString::fromUtf8(":"))
+			.append(m_dateMinutePart);
+
+	if (m_uniqueMinute == false) {
+		rep.append(QString::fromUtf8(":"))
 			.append(m_dateSecondPart);
+	}
+	if (m_uniqueMinute == true) {
+		qDebug() << "test";
+	}
 
 	switch (m_norlogeIndex)
 	{

--- a/core/qqnorloge.h
+++ b/core/qqnorloge.h
@@ -20,6 +20,10 @@ public:
 	void setNorlogeIndex(int index) { m_norlogeIndex = index;}
 	int norlogeIndex() { return m_norlogeIndex; }
 
+	void setUniqueMinute(bool unique) {
+		m_uniqueMinute = unique;
+	}
+
 protected:
 	QString m_srcBouchot;
 
@@ -31,6 +35,8 @@ protected:
 	QString m_dateSecondPart;
 
 	int m_norlogeIndex;
+
+	bool m_uniqueMinute;
 };
 
 #endif // QQNORLOGE_H

--- a/core/qqpost.cpp
+++ b/core/qqpost.cpp
@@ -39,7 +39,8 @@ QQPost::QQPost(const QQPost& post) :
 	m_isSelfPost(post.m_isSelfPost),
 	m_message(post.m_message),
 	m_id(post.m_id),
-	m_unread(post.m_unread)
+	m_unread(post.m_unread),
+	m_isAloneInMinute(post.m_isAloneInMinute)
 {
 }
 
@@ -99,6 +100,9 @@ QQNorloge QQPost::norlogeObj() const
 					  norloge());
 	if(isNorlogeMultiple())
 		targetN.setNorlogeIndex(norlogeIndex());
+
+	if(isAloneInMinute())
+		targetN.setUniqueMinute(true);
 
 	return targetN;
 }
@@ -164,6 +168,7 @@ void QQPost::reset()
 	m_norloge.clear();
 	m_norlogeIndex = 1;
 	m_isNorlogeMultiple = false;
+	m_isAloneInMinute = false;
 
 	m_login.clear();
 	m_ua.clear();
@@ -172,4 +177,5 @@ void QQPost::reset()
 	m_message.clear();
 	m_id.clear();
 	m_unread = true;
+
 }

--- a/core/qqpost.h
+++ b/core/qqpost.h
@@ -62,6 +62,9 @@ public:
 	void incrIndex() { this->m_norlogeIndex ++; }
 	bool isNorlogeMultiple() const { return this->m_isNorlogeMultiple || this->m_norlogeIndex > 1; }
 	void setNorlogeMultiple(const bool isNorlogeMultiple) { this->m_isNorlogeMultiple = isNorlogeMultiple; }
+	bool isAloneInMinute() const { return this->m_isAloneInMinute; }
+	void setAloneInMinute(const bool isAloneInMinute) { this->m_isAloneInMinute = isAloneInMinute; }
+	QString norlogeMinute() const { return this->norloge().remove(12,2); }
 
 	QDate date();
 
@@ -97,6 +100,7 @@ private:
 	QString m_norloge;
 	bool m_isNorlogeMultiple;
 	int m_norlogeIndex;
+	bool m_isAloneInMinute;
 
 	QString m_login;
 	QString m_ua;


### PR DESCRIPTION
This commit does not include the configuration. This is always on

Pour configurer l'affichage ou non, il faut changer la valeur du booleen [m_short_norloge](https://github.com/dguihal/quteqoin/compare/master...claudex:shortnologe?expand=1#diff-b29a143d1e87ffd6979f3ee463dcafe3R102).

Si tu as des questions ou si c'est de la merde, n'hésite pas à me le dire.